### PR TITLE
Add `network.server` to macos release entitlements

### DIFF
--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #17 

Missing server permissions in release mode:

```bash
flutter: [Launching]: https://accounts.spotify.com/authorize?response_type=code&client_id=&redirect_uri=http%3A%2F%2Flocalhost%3A4304%2Fauth%2Fspotify%2Fcallback&code_challenge=&code_challenge_method=S256&scope=user-library-read+user-library-modify+user-read-private+user-read-email+user-follow-read+user-follow-modify+playlist-read-collaborative
flutter: [connectIpc]: SocketException: Failed to create server socket (OS Error: Operation not permitted, errno = 1), address = 127.0.0.1, port = 4304
flutter: #0      _NativeSocket.bind (dart:io-patch/socket_patch.dart:988)
<asynchronous suspension>
#1      connectIpc (package:spotube/helpers/server_ipc.dart:11)
<asynchronous suspension>
#2      oauthLogin (package:spotube/helpers/oauth-login.dart:24)
<asynchronous suspension>

flutter: [oauthLogin()] SocketException: Failed to create server socket (OS Error: Operation not permitted, errno = 1), address = 127.0.0.1, port = 4304
flutter: #0      _NativeSocket.bind (dart:io-patch/socket_patch.dart:988)
<asynchronous suspension>
#1      connectIpc (package:spotube/helpers/server_ipc.dart:11)
<asynchronous suspension>
#2      oauthLogin (package:spotube/helpers/oauth-login.dart:24)
<asynchronous suspension>

[ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: SocketException: Failed to create server socket (OS Error: Operation not permitted, errno = 1), address = 127.0.0.1, port = 4304
#0      _NativeSocket.bind (dart:io-patch/socket_patch.dart:988)
<asynchronous suspension>
#1      connectIpc (package:spotube/helpers/server_ipc.dart:11)
<asynchronous suspension>
#2      oauthLogin (package:spotube/helpers/oauth-login.dart:24)
<asynchronous suspension>
```