### PR TITLE
README: fix license badge image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <img alt="GitHub release" src="https://img.shields.io/github/v/release/KRTirtho/spotube?color=%2316ba58&style=flat-square"/>
   </a>
   <a href="LICENSE">
-    <img alt="License" src="https://img.shields.io/aur/license/spotube?color=%2316ba58&style=flat-square"/>
+    <img alt="License" src="https://img.shields.io/aur/license/spotube-bin?color=%2316ba58&style=flat-square"/>
   </a>
   <a href="https://github.com/KRTirtho">
     <img alt="Maintainer" src="https://img.shields.io/badge/Maintainer-KRTirtho-%2316ba58?style=flat-square"/>


### PR DESCRIPTION
e1f66c9c7a9c14190e91a7a49169b346a3dd561e changed
the aur package name to spotube-bin, so the badge link
also needs to be updated.