### PR TITLE
[FIX] Fade Long Usernames on Sidebar

### DIFF
--- a/lib/components/Home/Sidebar.dart
+++ b/lib/components/Home/Sidebar.dart
@@ -148,28 +148,31 @@ class Sidebar extends HookConsumerWidget {
                                 child: CircularProgressIndicator(),
                               )
                             else if (data != null)
-                              Row(
-                                children: [
-                                  CircleAvatar(
-                                    backgroundImage:
-                                        CachedNetworkImageProvider(avatarImg),
-                                  ),
-                                  const SizedBox(
-                                    width: 10,
-                                  ),
-                                  SizedBox(
-                                    width: 120,
-                                    child: Text(
-                                      data.displayName ?? "Guest",
-                                      maxLines: 1,
-                                      softWrap: false,
-                                      overflow: TextOverflow.fade,
-                                      style: const TextStyle(
-                                        fontWeight: FontWeight.bold,
+                              Flexible(
+                                child: Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceEvenly,
+                                  children: [
+                                    CircleAvatar(
+                                      backgroundImage:
+                                          CachedNetworkImageProvider(avatarImg),
+                                    ),
+                                    const SizedBox(
+                                      width: 10,
+                                    ),
+                                    Flexible(
+                                      child: Text(
+                                        data.displayName ?? "Guest",
+                                        maxLines: 1,
+                                        softWrap: false,
+                                        overflow: TextOverflow.fade,
+                                        style: const TextStyle(
+                                          fontWeight: FontWeight.bold,
+                                        ),
                                       ),
                                     ),
-                                  ),
-                                ],
+                                  ],
+                                ),
                               ),
                             IconButton(
                                 icon: const Icon(Icons.settings_outlined),

--- a/lib/components/Home/Sidebar.dart
+++ b/lib/components/Home/Sidebar.dart
@@ -154,11 +154,19 @@ class Sidebar extends HookConsumerWidget {
                                     backgroundImage:
                                         CachedNetworkImageProvider(avatarImg),
                                   ),
-                                  const SizedBox(width: 10),
-                                  Text(
-                                    data.displayName ?? "Guest",
-                                    style: const TextStyle(
-                                      fontWeight: FontWeight.bold,
+                                  const SizedBox(
+                                    width: 10,
+                                  ),
+                                  SizedBox(
+                                    width: 120,
+                                    child: Text(
+                                      data.displayName ?? "Guest",
+                                      maxLines: 1,
+                                      softWrap: false,
+                                      overflow: TextOverflow.fade,
+                                      style: const TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                      ),
                                     ),
                                   ),
                                 ],


### PR DESCRIPTION
Previously long usernames would overflow off the sidebar hiding the settings button. Now long usernames will fade out making room for the settings button and preventing overflow off the sidebar.