### PR TITLE
Get Dependabot to target the dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "dev"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "dev"


### PR DESCRIPTION
Faster merges without breaking the mainline, plus it makes more sense