### PR TITLE
Force High Refresh Rate on some Android devices

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:spotube/hooks/use_init_sys_tray.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:flutter_displaymode/flutter_displaymode.dart';
 
 Future<void> main(List<String> rawArgs) async {
   final parser = ArgParser();
@@ -84,6 +85,9 @@ Future<void> main(List<String> rawArgs) async {
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
 
   MediaKit.ensureInitialized();
+
+  // force High Refresh Rate on some Android devices (like One Plus)
+  await FlutterDisplayMode.setHighRefreshRate();
 
   await DesktopTools.ensureInitialized(
     DesktopWindowOptions(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,7 +87,9 @@ Future<void> main(List<String> rawArgs) async {
   MediaKit.ensureInitialized();
 
   // force High Refresh Rate on some Android devices (like One Plus)
-  await FlutterDisplayMode.setHighRefreshRate();
+if (DesktopTools.platform.isAndroid) {
+    await FlutterDisplayMode.setHighRefreshRate();
+}
 
   await DesktopTools.ensureInitialized(
     DesktopWindowOptions(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -632,6 +632,14 @@ packages:
       url: "https://github.com/KRTirtho/flutter_desktop_tools.git"
     source: git
     version: "0.0.1"
+  flutter_displaymode:
+    dependency: "direct main"
+    description:
+      name: flutter_displaymode
+      sha256: "42c5e9abd13d28ed74f701b60529d7f8416947e58256e6659c5550db719c57ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   flutter_distributor:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -97,6 +97,7 @@ dependencies:
   duration: ^3.0.12
   disable_battery_optimization: ^1.1.0+1
   youtube_explode_dart: ^1.12.4
+  flutter_displaymode: ^0.6.0
 
 dev_dependencies:
   build_runner: ^2.3.2


### PR DESCRIPTION
Using an app in 60FPS on a 120+Hz screen is unbearable

One Plus is a usual suspect here, tested, works good

More info: https://pub.dev/packages/flutter_displaymode