### PR TITLE
Improve and unify the logging framework

### DIFF
--- a/bin/gen-credits.dart
+++ b/bin/gen-credits.dart
@@ -6,8 +6,11 @@ import 'package:http/http.dart';
 import 'package:html/parser.dart';
 import 'package:pub_api_client/pub_api_client.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:spotube/models/logger.dart';
 
 void main() async {
+  final logger = getLogger("");
+
   final client = PubClient();
 
   final pubspec = Pubspec.parse(File('pubspec.yaml').readAsStringSync());
@@ -68,7 +71,7 @@ void main() async {
     ),
   );
 
-  print(
+  logger.d(
     packageInfo
         .map(
           (package) =>
@@ -76,7 +79,7 @@ void main() async {
         )
         .join('\n'),
   );
-  print(
+  logger.d(
     gitPubspecs.map(
       (package) {
         final packageUrl = package.homepage ??

--- a/bin/gen-credits.dart
+++ b/bin/gen-credits.dart
@@ -6,11 +6,8 @@ import 'package:http/http.dart';
 import 'package:html/parser.dart';
 import 'package:pub_api_client/pub_api_client.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
-import 'package:spotube/models/logger.dart';
 
 void main() async {
-  final logger = getLogger("");
-
   final client = PubClient();
 
   final pubspec = Pubspec.parse(File('pubspec.yaml').readAsStringSync());
@@ -71,7 +68,8 @@ void main() async {
     ),
   );
 
-  logger.d(
+  // ignore: avoid_print
+  print(
     packageInfo
         .map(
           (package) =>
@@ -79,7 +77,8 @@ void main() async {
         )
         .join('\n'),
   );
-  logger.d(
+  // ignore: avoid_print
+  print(
     gitPubspecs.map(
       (package) {
         final packageUrl = package.homepage ??

--- a/bin/untranslated_messages.dart
+++ b/bin/untranslated_messages.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:spotube/models/logger.dart';
 
 /// Generate JSON output for untranslated messages with English values
 /// for quick translation in ChatGPT
@@ -14,8 +13,6 @@ import 'package:spotube/models/logger.dart';
 /// Example: dart bin/untranslated_messages.dart bn
 
 void main(List<String> args) {
-  final logger = getLogger("");
-
   final file = jsonDecode(
     File('untranslated_messages.json').readAsStringSync(),
   ) as Map<String, dynamic>;
@@ -38,7 +35,8 @@ void main(List<String> args) {
     );
   }
 
-  logger.d(
+  // ignore: avoid_print
+  print(
     const JsonEncoder.withIndent('  ').convert(
       args.isNotEmpty ? messagesWithValues[args.first] : messagesWithValues,
     ),

--- a/bin/untranslated_messages.dart
+++ b/bin/untranslated_messages.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:spotube/models/logger.dart';
 
 /// Generate JSON output for untranslated messages with English values
 /// for quick translation in ChatGPT
@@ -13,6 +14,8 @@ import 'dart:io';
 /// Example: dart bin/untranslated_messages.dart bn
 
 void main(List<String> args) {
+  final logger = getLogger("");
+
   final file = jsonDecode(
     File('untranslated_messages.json').readAsStringSync(),
   ) as Map<String, dynamic>;
@@ -35,7 +38,7 @@ void main(List<String> args) {
     );
   }
 
-  print(
+  logger.d(
     const JsonEncoder.withIndent('  ').convert(
       args.isNotEmpty ? messagesWithValues[args.first] : messagesWithValues,
     ),

--- a/bin/verify-pkgbuild.dart
+++ b/bin/verify-pkgbuild.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:spotube/models/logger.dart';
 
 void main() {
+  final logger = getLogger("");
   Process.run("sh", ["-c", '"./scripts/pkgbuild2json.sh aur-struct/PKGBUILD"'])
       .then((result) {
     try {
@@ -16,7 +18,7 @@ void main() {
       }
     } catch (e) {
       // ignore: avoid_print
-      print("[Failed to parse PKGBUILD] $e");
+      logger.e("[Failed to parse PKGBUILD] $e");
     }
   });
 }

--- a/bin/verify-pkgbuild.dart
+++ b/bin/verify-pkgbuild.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:spotube/models/logger.dart';
 
 void main() {
-  final logger = getLogger("");
   Process.run("sh", ["-c", '"./scripts/pkgbuild2json.sh aur-struct/PKGBUILD"'])
       .then((result) {
     try {
@@ -18,7 +16,7 @@ void main() {
       }
     } catch (e) {
       // ignore: avoid_print
-      logger.e("[Failed to parse PKGBUILD] $e");
+      print("[Failed to parse PKGBUILD] $e");
     }
   });
 }

--- a/lib/extensions/list.dart
+++ b/lib/extensions/list.dart
@@ -1,4 +1,7 @@
 import 'package:collection/collection.dart';
+import 'package:spotube/models/logger.dart';
+
+final logger = getLogger("List");
 
 extension MultiSortListMap on List<Map> {
   /// [preference] - List of properties in which you want to sort the list
@@ -18,7 +21,7 @@ extension MultiSortListMap on List<Map> {
       return this;
     }
     if (preference.length != criteria.length) {
-      print('Criteria length is not equal to preference');
+      logger.d('Criteria length is not equal to preference');
       return this;
     }
 
@@ -66,7 +69,7 @@ extension MultiSortListTupleMap<V> on List<(Map, V)> {
       return this;
     }
     if (preference.length != criteria.length) {
-      print('Criteria length is not equal to preference');
+      logger.d('Criteria length is not equal to preference');
       return this;
     }
 

--- a/lib/models/logger.dart
+++ b/lib/models/logger.dart
@@ -37,7 +37,8 @@ class SpotubeLogger extends Logger {
   SpotubeLogger([this.owner]) : super(filter: _SpotubeLogFilter());
 
   @override
-  void log(Level level, message, [error, StackTrace? stackTrace]) async {
+  void log(Level level, dynamic message,
+      {Object? error, StackTrace? stackTrace, DateTime? time}) async {
     if (!kIsWeb) {
       if (level == Level.error) {
         String dir = (await getApplicationDocumentsDirectory()).path;
@@ -56,7 +57,7 @@ class SpotubeLogger extends Logger {
       }
     }
 
-    super.log(level, "[$owner] $message", error, stackTrace);
+    super.log(level, "[$owner] $message", error: error, stackTrace: stackTrace);
   }
 }
 
@@ -64,7 +65,7 @@ class _SpotubeLogFilter extends DevelopmentFilter {
   @override
   bool shouldLog(LogEvent event) {
     if ((logEnv["DEBUG"] == "true" && event.level == Level.debug) ||
-        (logEnv["VERBOSE"] == "true" && event.level == Level.verbose) ||
+        (logEnv["VERBOSE"] == "true" && event.level == Level.trace) ||
         (logEnv["ERROR"] == "true" && event.level == Level.error)) {
       return true;
     }

--- a/lib/provider/proxy_playlist/next_fetcher_mixin.dart
+++ b/lib/provider/proxy_playlist/next_fetcher_mixin.dart
@@ -3,12 +3,15 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:spotify/spotify.dart';
 import 'package:spotube/models/local_track.dart';
+import 'package:spotube/models/logger.dart';
 import 'package:spotube/models/matched_track.dart';
 import 'package:spotube/models/spotube_track.dart';
 import 'package:spotube/provider/proxy_playlist/proxy_playlist.dart';
 import 'package:spotube/provider/user_preferences_provider.dart';
 import 'package:spotube/services/supabase.dart';
 import 'package:spotube/services/youtube/youtube.dart';
+
+final logger = getLogger("NextFetcherMixin");
 
 mixin NextFetcher on StateNotifier<ProxyPlaylist> {
   Future<List<SpotubeTrack>> fetchTracks(
@@ -123,8 +126,8 @@ mixin NextFetcher on StateNotifier<ProxyPlaylist> {
         );
       }
     } catch (e, stackTrace) {
-      debugPrint(e.toString());
-      debugPrintStack(stackTrace: stackTrace);
+      logger.e(e.toString());
+      logger.t(stackTrace);
     }
   }
 }

--- a/lib/provider/proxy_playlist/proxy_playlist_provider.dart
+++ b/lib/provider/proxy_playlist/proxy_playlist_provider.dart
@@ -586,7 +586,7 @@ class ProxyPlaylistNotifier extends PersistedStateNotifier<ProxyPlaylist>
           end,
         );
       }).toList();
-      getLogger('getSkipSegments').v(
+      getLogger('getSkipSegments').t(
         "[SponsorBlock] successfully fetched skip segments for $id",
       );
 

--- a/lib/services/download_manager/chunked_download.dart
+++ b/lib/services/download_manager/chunked_download.dart
@@ -3,6 +3,9 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:spotube/models/logger.dart';
+
+final logger = getLogger("ChunkedDownload");
 
 /// Downloading by spiting as file in chunks
 extension ChunkDownload on Dio {
@@ -67,11 +70,11 @@ extension ChunkDownload on Dio {
       }
       await raf.close();
 
-      debugPrint("Downloaded file path: ${headFile.path}");
+      logger.d("Downloaded file path: ${headFile.path}");
 
       headFile = await headFile.rename(savePath);
 
-      debugPrint("Renamed file path: ${headFile.path}");
+      logger.d("Renamed file path: ${headFile.path}");
     }
 
     final firstResponse = await downloadChunk(

--- a/lib/services/download_manager/download_manager.dart
+++ b/lib/services/download_manager/download_manager.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:spotube/models/logger.dart';
 import 'package:spotube/services/download_manager/chunked_download.dart';
 import 'package:spotube/services/download_manager/download_request.dart';
 import 'package:spotube/services/download_manager/download_status.dart';
@@ -22,6 +23,7 @@ typedef DownloadStatusEvent = ({
 });
 
 class DownloadManager {
+  final logger = getLogger("DownloadManager");
   final Map<String, DownloadTask> _cache = <String, DownloadTask>{};
   final Queue<DownloadRequest> _queue = Queue();
   var dio = Dio();
@@ -73,7 +75,7 @@ class DownloadManager {
       }
       setStatus(task, DownloadStatus.downloading);
 
-      debugPrint("[DownloadManager] $url");
+      logger.d("[DownloadManager] $url");
       final file = File(savePath.toString());
       partialFilePath = savePath + partialExtension;
       partialFile = File(partialFilePath);
@@ -82,10 +84,10 @@ class DownloadManager {
       final partialFileExist = await partialFile.exists();
 
       if (fileExist) {
-        debugPrint("[DownloadManager] File Exists");
+        logger.d("[DownloadManager] File Exists");
         setStatus(task, DownloadStatus.completed);
       } else if (partialFileExist) {
-        debugPrint("[DownloadManager] Partial File Exists");
+        logger.d("[DownloadManager] Partial File Exists");
 
         final partialFileLength = await partialFile.length();
 
@@ -205,7 +207,7 @@ class DownloadManager {
   }
 
   Future<void> pauseDownload(String url) async {
-    debugPrint("[DownloadManager] Pause Download");
+    logger.d("[DownloadManager] Pause Download");
     var task = getDownload(url)!;
     setStatus(task, DownloadStatus.paused);
     task.request.cancelToken.cancel();
@@ -214,7 +216,7 @@ class DownloadManager {
   }
 
   Future<void> cancelDownload(String url) async {
-    debugPrint("[DownloadManager] Cancel Download");
+    logger.d("[DownloadManager] Cancel Download");
     var task = getDownload(url)!;
     setStatus(task, DownloadStatus.canceled);
     _queue.remove(task.request);
@@ -222,7 +224,7 @@ class DownloadManager {
   }
 
   Future<void> resumeDownload(String url) async {
-    debugPrint("[DownloadManager] Resume Download");
+    logger.d("[DownloadManager] Resume Download");
     var task = getDownload(url)!;
     setStatus(task, DownloadStatus.downloading);
     task.request.cancelToken = CancelToken();
@@ -388,7 +390,7 @@ class DownloadManager {
 
     while (_queue.isNotEmpty && runningTasks < maxConcurrentTasks) {
       runningTasks++;
-      debugPrint('Concurrent workers: $runningTasks');
+      logger.d('Concurrent workers: $runningTasks');
       var currentRequest = _queue.removeFirst();
 
       await download(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1226,10 +1226,10 @@ packages:
     dependency: "direct main"
     description:
       name: logger
-      sha256: "7ad7215c15420a102ec687bb320a7312afd449bac63bfb1c60d9787c27b9767f"
+      sha256: ba3bc83117b2b49bdd723c0ea7848e8285a0fbc597ba09203b20d329d020c24a
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "2.0.2"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,7 +69,7 @@ dependencies:
   intl: ^0.18.0
   introduction_screen: ^3.0.2
   json_annotation: ^4.8.1
-  logger: ^1.1.0
+  logger: ^2.0.2
   media_kit: ^1.1.3
   media_kit_libs_audio: ^1.0.1
   metadata_god: ^0.5.0


### PR DESCRIPTION
This PR enhances our discombobulated logging framework by unifying all logs through our custom logger utility, replacing the use of print and debugPrint methods as suggested by Flutter. These changes streamline debugging across various packages, methods, and classes for improved efficiency.

Compared to the last PR #712 , I have updated some `logger.d` statements to `logger.e` and cleaned up some of the decorated outputs in the /bin directory so there should be less noise overall. Please do let me know if I should extend this to other log statements as well.