### PR TITLE
Updated README.md file - Debian installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This handy table lists all methods you can use to install Spotube:
       <a href="https://github.com/KRTirtho/spotube/releases/latest/download/Spotube-linux-x86_64.deb">
         <img width="220" alt="Debian/Ubuntu Download" src="https://user-images.githubusercontent.com/61944859/169097994-e92aff78-fd75-4c93-b6e4-f072a4b5a7ed.png">
       </a>
-      <p>Then run: <code>sudo apt install Spotube-linux-x86_64.deb</code></p>
+      <p>Then run: <code>sudo apt install ./Spotube-linux-x86_64.deb</code></p>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
This PR fixes a small typo in the README file. To install a local debian package using `apt`, path to the package should be specified, otherwise it gonna look at the system repositories to find the package.

Here is the screenshot to make it more clear
![image](https://github.com/KRTirtho/spotube/assets/23167933/94fd5b42-78f8-44dd-83a3-bfa8eba68912)
