### PR TITLE
Update copyright year in footer to 2023

### DIFF
--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -49,7 +49,7 @@ const Footer = () => {
           color: "white",
         }}
       >
-        © 2023, Spotube. All rights reserved
+        © {new Date().getFullYear()}, Spotube. All rights reserved
       </chakra.p>
 
       <Flex mx="-2">

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -49,7 +49,7 @@ const Footer = () => {
           color: "white",
         }}
       >
-        © 2022, Spotube. All rights reserved
+        © 2023, Spotube. All rights reserved
       </chakra.p>
 
       <Flex mx="-2">


### PR DESCRIPTION
## Description

This PR updates the copyright year in the `Footer.tsx` file.

## Changes

- Updated the copyright year from 2022 to 2023 in `Footer.tsx`

## Reason

The copyright year needed to be updated to the current year (2023) to keep the website up-to-date.

## Testing

Visual confirmation of the change in the footer on the website.