### PR TITLE
Dynamic Copyright Year in Footer

### DIFF
--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -49,7 +49,7 @@ const Footer = () => {
           color: "white",
         }}
       >
-        © 2023, Spotube. All rights reserved
+        © {new Date().getFullYear()}, Spotube. All rights reserved
       </chakra.p>
 
       <Flex mx="-2">

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -49,7 +49,7 @@ const Footer = () => {
           color: "white",
         }}
       >
-        © 2022, Spotube. All rights reserved
+        © 2023, Spotube. All rights reserved
       </chakra.p>
 
       <Flex mx="-2">


### PR DESCRIPTION
## Description

This PR makes the copyright year in the footer dynamic. Instead of manually updating the year, it now automatically gets the current year using JavaScript's `Date` object.

## Changes

- Replaced the hardcoded copyright year with `{new Date().getFullYear()}` in `Footer.tsx`

## Reason

This change ensures that the copyright year in the footer always displays the current year, reducing the need for manual updates.

## Testing

Visual confirmation of the change in the footer on the website.