### PR TITLE
Update CONTRIBUTION.md - Change development branch from master to dev

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -145,7 +145,7 @@ Do the following:
   flutter run -d <window|macos|linux|(<android-device-id>)>
   ```
 
-Do debugging/testing/build etc then submit to us with PR against the development branch (master) & we'll review your code
+Do debugging/testing/build etc then submit to us with PR against the development branch (dev) & we'll review your code
 
 
 ### Submit Translations


### PR DESCRIPTION
Currently, CONTRIBUTION.md says the development branch is master, when the code pull requests are actually going into dev, this PR changes the development branch in CONTRIBUTION.md to dev