### PR TITLE
Linux: Set application ID properly

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -2,7 +2,11 @@ cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "spotube")
-set(APPLICATION_ID "oss.krtirtho.spotube")
+if(UNIX AND NOT APPLE)
+  set(APPLICATION_ID "com.github.KRTirtho.Spotube")
+else()
+  set(APPLICATION_ID "oss.krtirtho.spotube")
+endif()
 
 cmake_policy(SET CMP0063 NEW)
 

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -105,7 +105,7 @@ static void my_application_init(MyApplication* self) {}
 
 MyApplication* my_application_new() {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
-                                     "com.github.KRTirtho.Spotube", APPLICATION_ID,
+                                     "application-id", APPLICATION_ID,
                                      "flags", G_APPLICATION_HANDLES_COMMAND_LINE | G_APPLICATION_HANDLES_OPEN,
                                      nullptr));
 }


### PR DESCRIPTION
This fixes window association issues on Linux.

Here's a before/after output from [`xprop`](https://man.archlinux.org/man/xprop.1.en):

Before:

```
$ xprop
...
_GTK_WINDOW_OBJECT_PATH(UTF8_STRING) = "/org/gtk/Application/anonymous/window/1"
_GTK_APPLICATION_OBJECT_PATH(UTF8_STRING) = "/org/gtk/Application/anonymous"
```

After:

```
$ xprop
...
_GTK_WINDOW_OBJECT_PATH(UTF8_STRING) = "/com/github/KRTirtho/Spotube/window/1"
_GTK_APPLICATION_OBJECT_PATH(UTF8_STRING) = "/com/github/KRTirtho/Spotube"
_GTK_APPLICATION_ID(UTF8_STRING) = "com.github.KRTirtho.Spotube"
```


