### PR TITLE
Add Up for grab checkbox to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -71,3 +71,10 @@ body:
       description: Anything else you'd like to include?
     validations:
       required: false
+  - type: checkboxes
+    attributes:
+      label: Self grab
+      description: If you are a developer and want to work on this issue yourself, you can check this box and wait for maintainer response. We welcome contributions!
+      options:
+        - label: I'm ready to work on this issue!
+          required: false

--- a/.github/ISSUE_TEMPLATE/new_feature.yml
+++ b/.github/ISSUE_TEMPLATE/new_feature.yml
@@ -36,3 +36,10 @@ body:
       description: Anything else you'd like to include?
     validations:
       required: false
+  - type: checkboxes
+    attributes:
+      label: Self grab
+      description: If you are a developer and want to work on this issue yourself, you can check this box and wait for maintainer response. We welcome contributions!
+      options:
+        - label: I'm ready to work on this issue!
+          required: false


### PR DESCRIPTION
As there are so many issues that are waiting for a response, and some contributors are waiting for criteria acceptance, I think it's good to add a checkbox for developers that want to self-assign issues. So maintainer/maintainers or even outside contributors can better prioritize issues.