### PR TITLE
Install Visual C++ 2015-2022 Redistributable if missing when installing on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ publishaur:
 
 innoinstall:
 						powershell curl -o build\installer.exe http://files.jrsoftware.org/is/6/innosetup-${INNO_VERSION}.exe
+						powershell git clone https://github.com/DomGries/InnoDependencyInstaller.git  build\inno-depend
 		 				powershell build\installer.exe /verysilent /allusers /dir=build\iscc
 
 inno:

--- a/windows/packaging/exe/inno_setup.iss
+++ b/windows/packaging/exe/inno_setup.iss
@@ -1,0 +1,76 @@
+; https://github.com/DomGries/InnoDependencyInstaller
+; requires netcorecheck.exe and netcorecheck_x64.exe (see CodeDependencies.iss)
+; path is relative to dist\{VERSION} directory
+#define public Dependency_Path_NetCoreCheck "..\..\build\inno-depend\dependencies\"
+#include "..\..\build\inno-depend\CodeDependencies.iss"
+
+[Setup]
+AppId={{APP_ID}}
+AppVersion={{APP_VERSION}}
+AppName={{DISPLAY_NAME}}
+AppPublisher={{PUBLISHER_NAME}}
+AppPublisherURL={{PUBLISHER_URL}}
+AppSupportURL={{PUBLISHER_URL}}
+AppUpdatesURL={{PUBLISHER_URL}}
+DefaultDirName={{INSTALL_DIR_NAME}}
+DisableProgramGroupPage=yes
+OutputDir=.
+OutputBaseFilename={{OUTPUT_BASE_FILENAME}}
+Compression=lzma
+SolidCompression=yes
+SetupIconFile={{SETUP_ICON_FILE}}
+WizardStyle=modern
+PrivilegesRequired={{PRIVILEGES_REQUIRED}}
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+
+[Languages]
+{% for locale in LOCALES %}
+{% if locale == 'en' %}Name: "english"; MessagesFile: "compiler:Default.isl"{% endif %}
+{% if locale == 'hy' %}Name: "armenian"; MessagesFile: "compiler:Languages\\Armenian.isl"{% endif %}
+{% if locale == 'bg' %}Name: "bulgarian"; MessagesFile: "compiler:Languages\\Bulgarian.isl"{% endif %}
+{% if locale == 'ca' %}Name: "catalan"; MessagesFile: "compiler:Languages\\Catalan.isl"{% endif %}
+{% if locale == 'zh' %}Name: "chinesesimplified"; MessagesFile: "compiler:Languages\\ChineseSimplified.isl"{% endif %}
+{% if locale == 'co' %}Name: "corsican"; MessagesFile: "compiler:Languages\\Corsican.isl"{% endif %}
+{% if locale == 'cs' %}Name: "czech"; MessagesFile: "compiler:Languages\\Czech.isl"{% endif %}
+{% if locale == 'da' %}Name: "danish"; MessagesFile: "compiler:Languages\\Danish.isl"{% endif %}
+{% if locale == 'nl' %}Name: "dutch"; MessagesFile: "compiler:Languages\\Dutch.isl"{% endif %}
+{% if locale == 'fi' %}Name: "finnish"; MessagesFile: "compiler:Languages\\Finnish.isl"{% endif %}
+{% if locale == 'fr' %}Name: "french"; MessagesFile: "compiler:Languages\\French.isl"{% endif %}
+{% if locale == 'de' %}Name: "german"; MessagesFile: "compiler:Languages\\German.isl"{% endif %}
+{% if locale == 'he' %}Name: "hebrew"; MessagesFile: "compiler:Languages\\Hebrew.isl"{% endif %}
+{% if locale == 'is' %}Name: "icelandic"; MessagesFile: "compiler:Languages\\Icelandic.isl"{% endif %}
+{% if locale == 'it' %}Name: "italian"; MessagesFile: "compiler:Languages\\Italian.isl"{% endif %}
+{% if locale == 'ja' %}Name: "japanese"; MessagesFile: "compiler:Languages\\Japanese.isl"{% endif %}
+{% if locale == 'no' %}Name: "norwegian"; MessagesFile: "compiler:Languages\\Norwegian.isl"{% endif %}
+{% if locale == 'pl' %}Name: "polish"; MessagesFile: "compiler:Languages\\Polish.isl"{% endif %}
+{% if locale == 'pt' %}Name: "portuguese"; MessagesFile: "compiler:Languages\\Portuguese.isl"{% endif %}
+{% if locale == 'ru' %}Name: "russian"; MessagesFile: "compiler:Languages\\Russian.isl"{% endif %}
+{% if locale == 'sk' %}Name: "slovak"; MessagesFile: "compiler:Languages\\Slovak.isl"{% endif %}
+{% if locale == 'sl' %}Name: "slovenian"; MessagesFile: "compiler:Languages\\Slovenian.isl"{% endif %}
+{% if locale == 'es' %}Name: "spanish"; MessagesFile: "compiler:Languages\\Spanish.isl"{% endif %}
+{% if locale == 'tr' %}Name: "turkish"; MessagesFile: "compiler:Languages\\Turkish.isl"{% endif %}
+{% if locale == 'uk' %}Name: "ukrainian"; MessagesFile: "compiler:Languages\\Ukrainian.isl"{% endif %}
+{% endfor %}
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: {% if CREATE_DESKTOP_ICON != true %}unchecked{% else %}checkedonce{% endif %}
+Name: "launchAtStartup"; Description: "{cm:AutoStartProgram,{{DISPLAY_NAME}}}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: {% if LAUNCH_AT_STARTUP != true %}unchecked{% else %}checkedonce{% endif %}
+[Files]
+Source: "{{SOURCE_DIR}}\\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+
+[Icons]
+Name: "{autoprograms}\\{{DISPLAY_NAME}}"; Filename: "{app}\\{{EXECUTABLE_NAME}}"
+Name: "{autodesktop}\\{{DISPLAY_NAME}}"; Filename: "{app}\\{{EXECUTABLE_NAME}}"; Tasks: desktopicon
+Name: "{userstartup}\\{{DISPLAY_NAME}}"; Filename: "{app}\\{{EXECUTABLE_NAME}}"; WorkingDir: "{app}"; Tasks: launchAtStartup
+
+[Run]
+Filename: "{app}\\{{EXECUTABLE_NAME}}"; Description: "{cm:LaunchProgram,{{DISPLAY_NAME}}}"; Flags: {% if PRIVILEGES_REQUIRED == 'admin' %}runascurrentuser{% endif %} nowait postinstall skipifsilent
+
+[Code]
+function InitializeSetup: Boolean;
+begin
+  Dependency_AddVC2015To2022;
+  Result := True;
+end;

--- a/windows/packaging/exe/make_config.yaml
+++ b/windows/packaging/exe/make_config.yaml
@@ -4,5 +4,6 @@ publisher_url: https://github.com/KRTirtho/spotube
 display_name: Spotube
 create_desktop_icon: true
 install_dir_name: Spotube
+script_template: inno_setup.iss
 locales:
   - en


### PR DESCRIPTION
Fixes #1191 ( discussions #549 and #1200 )

Makefile now clones https://github.com/DomGries/InnoDependencyInstaller

Using custom Inno setup config as per https://distributor.leanflutter.dev/makers/exe/#custom-inno-setup-template

Tested under Windows Sandbox
![vc-redist-sandbox](https://github.com/KRTirtho/spotube/assets/1408881/e02d3472-1f01-461d-a0fb-5646db86174a)
