### PR TITLE
feat(linux): Use XDG_STATE_HOME to storage logs

### DIFF
--- a/lib/services/logger/logger.dart
+++ b/lib/services/logger/logger.dart
@@ -99,11 +99,11 @@ class AppLogger {
     // See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
     // TODO: Use path_provider once it supports XDG_STATE_HOME
     if (const bool.hasEnvironment("XDG_STATE_HOME")) {
-      String xdgStateHomeRaw = const String.fromEnvironment("XDG_STATE_HOME");
+      String xdgStateHomeRaw = Platform.environment["XDG_STATE_HOME"] ?? "";
       if (xdgStateHomeRaw.isNotEmpty) {
         return xdgStateHomeRaw;
       }
     }
-    return join(const String.fromEnvironment("HOME"), ".local", "state");
+    return join(Platform.environment["HOME"] ?? "", ".local", "state");
   }
 }

--- a/lib/services/logger/logger.dart
+++ b/lib/services/logger/logger.dart
@@ -98,12 +98,12 @@ class AppLogger {
     // which is the specification to store application logs on Linux.
     // See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
     // TODO: Use path_provider once it supports XDG_STATE_HOME
-    if (bool.hasEnvironment("XDG_STATE_HOME")) {
-      String xdgStateHomeRaw = String.fromEnvironment("XDG_STATE_HOME");
-      if (!xdgStateHomeRaw.isEmpty) {
+    if (const bool.hasEnvironment("XDG_STATE_HOME")) {
+      String xdgStateHomeRaw = const String.fromEnvironment("XDG_STATE_HOME");
+      if (xdgStateHomeRaw.isNotEmpty) {
         return xdgStateHomeRaw;
       }
     }
-    return join(String.fromEnvironment("HOME"), ".local", "state");
+    return join(const String.fromEnvironment("HOME"), ".local", "state");
   }
 }

--- a/lib/services/logger/logger.dart
+++ b/lib/services/logger/logger.dart
@@ -64,6 +64,11 @@ class AppLogger {
     if (kIsMacOS) {
       dir = join((await getLibraryDirectory()).path, "Logs");
     }
+
+    if (kIsLinux) {
+      dir = join(_getXdgStateHome(), "spotube");
+    }
+
     final file = File(join(dir, ".spotube_logs"));
     if (!await file.exists()) {
       await file.create(recursive: true);
@@ -86,5 +91,19 @@ class AppLogger {
         mode: FileMode.writeOnlyAppend,
       );
     }
+  }
+
+  static String _getXdgStateHome() {
+    // path_provider seems does not support XDG_STATE_HOME,
+    // which is the specification to store application logs on Linux.
+    // See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+    // TODO: Use path_provider once it supports XDG_STATE_HOME
+    if (bool.hasEnvironment("XDG_STATE_HOME")) {
+      String xdgStateHomeRaw = String.fromEnvironment("XDG_STATE_HOME");
+      if (!xdgStateHomeRaw.isEmpty) {
+        return xdgStateHomeRaw;
+      }
+    }
+    return join(String.fromEnvironment("HOME"), ".local", "state");
   }
 }


### PR DESCRIPTION
We storage logs at `~/Documents/.spotube_logs` on Linux currently, this does not follow XDG specification. XDG specification is used by many modern GUI apps to storage data on Linux.