### PR TITLE
Update ambiguous credential translations

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -160,7 +160,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "الترخيص",
   "add_spotify_credentials": "أضف بيانات Spotify الخاصة بك للبدء",
-  "credentials_will_not_be_shared_disclaimer": "لا تقلق، لن يتم جمع أي من بيانات الخاصة بك أو مشاركتها مع أي شخص",
+  "credentials_will_not_be_shared_disclaimer": "لا تقلق، لن يتم جمع أي من بيانات الاعتماد الخاصة بك أو مشاركتها مع أي شخص",
   "know_how_to_login": "لا تعرف كيف تفعل هذا؟",
   "follow_step_by_step_guide": "اتبع الدليل خطوة بخطوة",
   "spotify_cookie": "Spotify {name} كوكيز",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} কিংকর রায় তীর্থ",
   "license": "লাইসেন্স",
   "add_spotify_credentials": "আপনার Spotify লগইন তথ্য যোগ করুন",
-  "credentials_will_not_be_shared_disclaimer": "চিন্তা করবেন না, আপনার কোনো লগইন তথ্য সংগ্রহ করা হবে না বা কারো সাথে শেয়ার করা হবে না",
+  "credentials_will_not_be_shared_disclaimer": "চিন্তা করবেন না, আপনার কোনো শংসাপত্র সংগ্রহ বা কারো সাথে শেয়ার করা হবে না",
   "know_how_to_login": "আপনি কিভাবে লগইন করবেন তা জানেন না?",
   "follow_step_by_step_guide": "ধাপে ধাপে নির্দেশিকা অনুসরণ করুন",
   "spotify_cookie": "Spotify {name} কুকি",

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Llicència",
   "add_spotify_credentials": "Afegir les seves credencials de Spotify per començar",
-  "credentials_will_not_be_shared_disclaimer": "No es preocupi, les seves credencials no seran recollides ni compartides amb ningú",
+  "credentials_will_not_be_shared_disclaimer": "No us preocupeu, cap de les vostres credencials es recopilarà ni es compartirà amb ningú",
   "know_how_to_login": "No sap com fer-ho?",
   "follow_step_by_step_guide": "Segueixi la guia pas a pas",
   "spotify_cookie": "Cookie de Spotify {name}",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -161,7 +161,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Licence",
   "add_spotify_credentials": "Přidejte své přihlašovací údaje Spotify a začněte",
-  "credentials_will_not_be_shared_disclaimer": "Nebojte, žádné z vašich údajů nebudou shromažďovány ani s nikým sdíleny",
+  "credentials_will_not_be_shared_disclaimer": "Nemějte obavy, žádné z vašich přihlašovacích údajů nebudou shromažďovány ani sdíleny s nikým",
   "know_how_to_login": "Nevíte, jak na to?",
   "follow_step_by_step_guide": "Postupujte podle návodu",
   "spotify_cookie": "Cookie Spotify {name}",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Lizenz",
   "add_spotify_credentials": "Fügen Sie Ihre Spotify-Anmeldeinformationen hinzu, um zu starten",
-  "credentials_will_not_be_shared_disclaimer": "Keine Sorge, Ihre Anmeldeinformationen werden nicht erfasst oder mit anderen geteilt",
+  "credentials_will_not_be_shared_disclaimer": "Keine Sorge, Ihre Zugangsdaten werden nicht erfasst oder an Dritte weitergegeben",
   "know_how_to_login": "Wissen Sie nicht, wie es geht?",
   "follow_step_by_step_guide": "Befolgen Sie die schrittweise Anleitung",
   "spotify_cookie": "Spotify {name} Cookie",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -164,7 +164,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "License",
   "add_spotify_credentials": "Add your spotify credentials to get started",
-  "credentials_will_not_be_shared_disclaimer": "Don't worry, any of your credentials won't be collected or shared with anyone",
+  "credentials_will_not_be_shared_disclaimer": "Don't worry, none of your credentials will be collected or shared with anyone",
   "know_how_to_login": "Don't know how to do this?",
   "follow_step_by_step_guide": "Follow along the Step by Step guide",
   "spotify_cookie": "Spotify {name} Cookie",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Licencia",
   "add_spotify_credentials": "Agrega tus credenciales de Spotify para comenzar",
-  "credentials_will_not_be_shared_disclaimer": "No te preocupes, tus credenciales no serán recopiladas ni compartidas con nadie",
+  "credentials_will_not_be_shared_disclaimer": "No se preocupe, ninguna de sus credenciales será recopilada ni compartida con nadie",
   "know_how_to_login": "¿No sabes cómo hacerlo?",
   "follow_step_by_step_guide": "Sigue la guía paso a paso",
   "spotify_cookie": "Cookie de Spotify {name}",

--- a/lib/l10n/app_eu.arb
+++ b/lib/l10n/app_eu.arb
@@ -161,7 +161,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Lizentzia",
   "add_spotify_credentials": "Gehitu zure Spotify kredentzialak hasi ahal izateko",
-  "credentials_will_not_be_shared_disclaimer": "Ez arduratu, zure kredentzialak ez ditugu bilduko edo inorekin elkarbanatuko",
+  "credentials_will_not_be_shared_disclaimer": "Ez kezkatu, zure kredentzialetako bat ere ez da inorekin bilduko edo partekatuko",
   "know_how_to_login": "Ez dakizu nola egin?",
   "follow_step_by_step_guide": "Jarraitu pausoz-pausoko gida",
   "spotify_cookie": "Spotify-ren {name} cookiea",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -160,7 +160,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "مجوز",
   "add_spotify_credentials": "برای شروع اعتبار اسپوتیفای خود را اضافه کنید",
-  "credentials_will_not_be_shared_disclaimer": "نگران نباشید هیچ کدوما از اعتبارات شما جمع اوری نمیشود یا با کسی اشتراک گزاشته نمیشود",
+  "credentials_will_not_be_shared_disclaimer": "نگران نباشید، هیچ یک از اعتبارنامه های شما جمع آوری نمی شود یا با کسی به اشتراک گذاشته نمی شود",
   "know_how_to_login": "نمیدانی چگونه این کار را انجام بدهی؟",
   "follow_step_by_step_guide": "راهنما را گام به گام دنبال کنید",
   "spotify_cookie": "Spotify {name} کوکی",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -161,7 +161,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Lisenssi",
   "add_spotify_credentials": "Lisää Spotify-tunnuksesi aloittaaksesi",
-  "credentials_will_not_be_shared_disclaimer": "Älä huoli, tunnuksiasi ei talleteta tai jaeta kenenkään kanssa",
+  "credentials_will_not_be_shared_disclaimer": "Älä huoli, mitään kirjautumistietojasi ei kerätä tai jaeta kenenkään kanssa",
   "know_how_to_login": "Etkö tiedä miten tehdä tämä?",
   "follow_step_by_step_guide": "Seuraa askel askeleelta opasta",
   "spotify_cookie": "Spotify {name} Keksi",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Licence",
   "add_spotify_credentials": "Ajoutez vos identifiants Spotify pour commencer",
-  "credentials_will_not_be_shared_disclaimer": "Ne vous inquiétez pas, vos identifiants ne seront ni collectés ni partagés avec qui que ce soit",
+  "credentials_will_not_be_shared_disclaimer": "Ne vous inquiétez pas, aucun de vos identifiants ne sera collecté ou partagé avec qui que ce soit",
   "know_how_to_login": "Vous ne savez pas comment faire?",
   "follow_step_by_step_guide": "Suivez le guide étape par étape",
   "spotify_cookie": "Cookie Spotify {name}",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} किंगकोर रॉय तिर्थो",
   "license": "लाइसेंस",
   "add_spotify_credentials": "शुरू होने के लिए अपने स्पॉटिफाई क्रेडेंशियल जोड़ें",
-  "credentials_will_not_be_shared_disclaimer": "चिंता न करें, आपके क्रेडेंशियल किसी भी तरह से नहीं एकत्रित या साझा किए जाएंगे",
+  "credentials_will_not_be_shared_disclaimer": "चिंता न करें, आपका कोई भी क्रेडेंशियल एकत्र या किसी के साथ साझा नहीं किया जाएगा",
   "know_how_to_login": "इसे कैसे करें पता नहीं?",
   "follow_step_by_step_guide": "कदम से कदम गाइड के साथ चलें",
   "spotify_cookie": "स्पॉटिफाई {name} कुकी",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -161,7 +161,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Lisensi",
   "add_spotify_credentials": "Tambahkan kredensial Spotify Anda untuk memulai",
-  "credentials_will_not_be_shared_disclaimer": "Jangan khawatir, kredensial Anda tidak akan dikumpulkan atau dibagikan kepada siapa pun",
+  "credentials_will_not_be_shared_disclaimer": "Jangan khawatir, tidak ada kredensial Anda yang akan dikumpulkan atau dibagikan kepada siapa pun",
   "know_how_to_login": "Tidak tahu bagaimana melakukan ini?",
   "follow_step_by_step_guide": "Ikuti panduan Langkah demi Langkah",
   "spotify_cookie": "Spotify {name} Cookie",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -160,7 +160,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Licenza",
   "add_spotify_credentials": "Aggiungi le tue credenziali spotify per iniziare",
-  "credentials_will_not_be_shared_disclaimer": "Non ti preoccupare, le tue credenziali non saranno inviate o condivise con nessuno",
+  "credentials_will_not_be_shared_disclaimer": "Non preoccuparti, nessuna delle tue credenziali verrà raccolta o condivisa con nessuno",
   "know_how_to_login": "Non sai come farlo?",
   "follow_step_by_step_guide": "Segui la guida passo-passo",
   "spotify_cookie": "Cookie Spotify {name}",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "ライセンス",
   "add_spotify_credentials": "Spotify のログイン情報を追加してはじめましょう",
-  "credentials_will_not_be_shared_disclaimer": "心配ありません。個人情報を収集したり、共有されることはありません",
+  "credentials_will_not_be_shared_disclaimer": "心配しないでください。あなたの認証情報が収集されたり、誰かと共有されたりすることはありません。",
   "know_how_to_login": "やり方が分からないですか？",
   "follow_step_by_step_guide": "やり方の説明を見る",
   "spotify_cookie": "Spotify {name} Cookies",

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -161,7 +161,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "ლიცენზია",
   "add_spotify_credentials": "დასაწყებად დაამატეთ თქვენი Spotify მონაცემები",
-  "credentials_will_not_be_shared_disclaimer": "არ ინერვიულოთ, თქვენი მონაცემები არ იქნება შეგროვებული ან გაზიარებული ვინმესთან",
+  "credentials_will_not_be_shared_disclaimer": "არ ინერვიულოთ, თქვენი რწმუნებათა სიგელები არ იქნება შეგროვებული ან გაზიარებული ვინმესთან",
   "know_how_to_login": "არ იცით როგორ გააკეთოთ ეს?",
   "follow_step_by_step_guide": "მიჰყევით ნაბიჯ-ნაბიჯ სახელმძღვანელოს",
   "spotify_cookie": "Spotify {name} ქუქი",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "라이선스",
   "add_spotify_credentials": "먼저 Spotify의 로그인정보를 추가하기",
-  "credentials_will_not_be_shared_disclaimer": "걱정마세요. 개인정보를 수집하거나 공유하지 않습니다.",
+  "credentials_will_not_be_shared_disclaimer": "걱정하지 마세요. 귀하의 자격 증명은 수집되지 않으며 누구와도 공유되지 않습니다.",
   "know_how_to_login": "어떻게 하는건지 모르겠나요?",
   "follow_step_by_step_guide": "사용법 확인하기",
   "spotify_cookie": "Spotify {name} Cookies",

--- a/lib/l10n/app_ne.arb
+++ b/lib/l10n/app_ne.arb
@@ -160,7 +160,7 @@
   "copyright": "© 2021-{current_year} किङ्कोर राय तिर्थो",
   "license": "लाइसेन्स",
   "add_spotify_credentials": "सुरु हुनका लागि तपाईंको स्पटिफाई क्रेडेन्शियल थप्नुहोस्",
-  "credentials_will_not_be_shared_disclaimer": "चिन्ता नगर्नुहोस्, तपाईंको कुनै पनि क्रेडेन्शियलहरूले कसैले संग्रह वा साझा गर्नेछैन",
+  "credentials_will_not_be_shared_disclaimer": "चिन्ता नगर्नुहोस्, तपाईंको कुनै पनि प्रमाणहरू सङ्कलन वा कसैसँग साझेदारी गरिने छैन",
   "know_how_to_login": "कसरी लगिन गर्ने भन्ने थाहा छैन?",
   "follow_step_by_step_guide": "चरणबद्ध मार्गदर्शनमा साथी बनाउनुहोस्",
   "spotify_cookie": "Spotify {name} कुकी",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -160,7 +160,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Licentie",
   "add_spotify_credentials": "Voeg om te beginnen je spotify-aanmeldgegevens toe",
-  "credentials_will_not_be_shared_disclaimer": "Maak je geen zorgen, je gegevens worden niet verzameld of gedeeld met anderen.",
+  "credentials_will_not_be_shared_disclaimer": "Maak je geen zorgen, er worden geen gegevens van je verzameld of met iemand gedeeld.",
   "know_how_to_login": "Weet je niet hoe je dit moet doen?",
   "follow_step_by_step_guide": "Volg de stapsgewijze handleiding",
   "spotify_cookie": "Spotify {name} Cookie",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Licencja",
   "add_spotify_credentials": "Dodaj swoje dane logowania Spotify, aby zacząć",
-  "credentials_will_not_be_shared_disclaimer": "Nie martw się, żadne dane logowania nie są zbierane ani udostępniane nikomu",
+  "credentials_will_not_be_shared_disclaimer": "Nie martw się, żadne Twoje dane uwierzytelniające nie zostaną zebrane ani nikomu udostępnione",
   "know_how_to_login": "Nie wiesz, jak się zalogować?",
   "follow_step_by_step_guide": "Postępuj zgodnie z poradnikiem krok po kroku",
   "spotify_cookie": "Spotify {name} Ciasteczko",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Licença",
   "add_spotify_credentials": "Adicione suas credenciais do Spotify para começar",
-  "credentials_will_not_be_shared_disclaimer": "Não se preocupe, suas credenciais não serão coletadas nem compartilhadas com ninguém",
+  "credentials_will_not_be_shared_disclaimer": "Não se preocupe, nenhuma das suas credenciais será coletada ou compartilhada com ninguém",
   "know_how_to_login": "Não sabe como fazer isso?",
   "follow_step_by_step_guide": "Siga o guia passo a passo",
   "spotify_cookie": "Cookie do Spotify {name}",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Лицензия",
   "add_spotify_credentials": "Добавьте ваши учетные данные Spotify, чтобы начать",
-  "credentials_will_not_be_shared_disclaimer": "Не беспокойся, никакая личная информация не собирается и не передается",
+  "credentials_will_not_be_shared_disclaimer": "Не волнуйтесь, никакие ваши учетные данные не будут собраны или переданы кому-либо",
   "know_how_to_login": "Не знаете, как это сделать?",
   "follow_step_by_step_guide": "Следуйте пошаговому руководству",
   "spotify_cookie": "Spotify {name} Cookie",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -161,7 +161,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "ใบอนุญาต",
   "add_spotify_credentials": "เพิ่มข้อมูลรับรอง Spotify ของคุณเพื่อเริ่มต้น",
-  "credentials_will_not_be_shared_disclaimer": "ไม่ต้องกังวล ข้อมูลรับรองใดๆ ของคุณจะไม่ถูกเก็บรวบรวมหรือแชร์กับใคร",
+  "credentials_will_not_be_shared_disclaimer": "ไม่ต้องกังวล ข้อมูลประจำตัวของคุณจะไม่ถูกรวบรวมหรือแบ่งปันกับใคร",
   "know_how_to_login": "ไม่รู้จักวิธีดำเนินการนี้ใช่ไหม",
   "follow_step_by_step_guide": "ทำตามคู่มือทีละขั้น",
   "spotify_cookie": "คุกกี้ Spotify {name}",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -160,7 +160,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Ліцензія",
   "add_spotify_credentials": "Додайте свої облікові дані Spotify, щоб почати",
-  "credentials_will_not_be_shared_disclaimer": "Не хвилюйтеся, жодні ваші облікові дані не будуть зібрані або передані кому-небудь",
+  "credentials_will_not_be_shared_disclaimer": "Не хвилюйтеся, жодні ваші облікові дані не будуть зібрані чи комусь надані",
   "know_how_to_login": "Не знаєте, як це зробити?",
   "follow_step_by_step_guide": "Дотримуйтесь покрокової інструкції",
   "spotify_cookie": "Кукі-файл Spotify {name}",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -160,7 +160,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "Giấy phép",
   "add_spotify_credentials": "Điền thông tin đăng nhập Spotify của bạn",
-  "credentials_will_not_be_shared_disclaimer": "Đừng lo, thông tin đăng nhập của bạn sẽ không được thu thập hoặc chia sẻ với bất kỳ ai",
+  "credentials_will_not_be_shared_disclaimer": "Đừng lo lắng, không có thông tin đăng nhập nào của bạn sẽ được thu thập hoặc chia sẻ với bất kỳ ai",
   "know_how_to_login": "Không biết cách lấy thông tin đăng nhập?",
   "follow_step_by_step_guide": "Các bước lấy thông tin đăng nhập",
   "spotify_cookie": "Cookie Spotify {name}",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -158,7 +158,7 @@
   "copyright": "© 2021-{current_year} Kingkor Roy Tirtho",
   "license": "许可证",
   "add_spotify_credentials": "添加你的 Spotify 登录信息以开始使用",
-  "credentials_will_not_be_shared_disclaimer": "不用担心，软件不会收集或分享任何个人数据给第三方",
+  "credentials_will_not_be_shared_disclaimer": "不用担心，您的任何凭据都不会被收集或与任何人共享",
   "know_how_to_login": "不知道该怎么做？",
   "follow_step_by_step_guide": "请按照以下指南进行",
   "spotify_cookie": "Spotify {name} Cookie",


### PR DESCRIPTION
Turkish remains unchanged for some reason, I guess it was already correct to begin with.