### PR TITLE
pluralize genre in "Select up to 5 Genre" in playlist_generate.dart

### DIFF
--- a/lib/pages/library/playlist_generate/playlist_generate.dart
+++ b/lib/pages/library/playlist_generate/playlist_generate.dart
@@ -199,7 +199,7 @@ class PlaylistGeneratorPage extends HookConsumerWidget {
       label: Text(context.l10n.add_genres),
       helperText: context.l10n.select_up_to_count_type(
         leftSeedCount,
-        context.l10n.genre,
+        context.l10n.genres,
       ),
       enabled: enabled,
     );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3069f6a3-8339-4825-ab12-3ff5ca199352)

the word "Genre" in "Select up to 5 Genre" should be plural to be align with the other descriptions

![image](https://github.com/user-attachments/assets/c05d3e4d-940b-41c6-9640-173e62058813)
