### PR TITLE
Introducing script Spotube .tar.xz based linux updater 

### DIFF
--- a/update_spotube_on_linux.sh
+++ b/update_spotube_on_linux.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Written 10. Okt. 2024 4pm Berlin Time (CEST)
+
 # Script to update Spotube on Linux (direct binaries via tar.xz)
 # For letting it run in a crontab or manually
 

--- a/update_spotube_on_linux.sh
+++ b/update_spotube_on_linux.sh
@@ -2,17 +2,13 @@
 # Script to update Spotube on Linux (direct binaries via tar.xz)
 # For letting it run in a crontab or manually
 
-# arch possibilities: either aarch64 or x86_6
-# path and tmpf (temp file for .tar.xz) whatever you choose
-
 # less sophisticated, old oneliner: arch="aarch64";p="/usr/share/spotube-bin"; a=$(curl -s https://api.github.com/repos/krtirtho/spotube/releases/latest | sed 's/[()",{}]/ /g; s/ /\n/g' | grep "https.*releases/download.*tar.xz" | grep "$arch"); wget "$a" -O "$p/test.tar.xz" && tar -xJf "$p/test.tar.xz"  && rm "$p/test.tar.xz" && echo "$(date -I'seconds')|$a" >> "$p/lastupdate.txt"
 
-
 p="/usr/share/spotube-bin" # Path where the tar.xz should be downloaded and unpacked
-tmpf="$p/test.tar.xz"
+tmpf="$p/test.tar.xz" # temporary .tar.xz name and location (within Path p)
 repo="krtirtho/spotube" # define repo path
+arch="x86_64" # arch? either aarch64 or x86_64
 url="https://api.github.com/repos/$repo/releases/latest"
-arch="x86_64" # arch?
 
 # check if running as root
 if [ $(id -u) -ne 0 ]; then

--- a/update_spotube_on_linux.sh
+++ b/update_spotube_on_linux.sh
@@ -11,6 +11,7 @@ tmpf="$p/test.tar.xz" # temporary .tar.xz name and location (within Path p)
 repo="krtirtho/spotube" # define repo path
 arch="x86_64" # arch? either aarch64 or x86_64
 url="https://api.github.com/repos/$repo/releases/latest"
+user="dnr"
 
 # check if running as root
 if [ $(id -u) -ne 0 ]; then
@@ -32,9 +33,15 @@ fi
 # rm "$p/*" -r # optionally remove everything in the folder before (avoiding left overs and other issues)
 
 # creating $p dir, downloading & saving, unpacking tmpf/tar.xz
-mkdir -p "$p" # add directory if not yet existing (including subtree)
-curl -L -s -o "$p/test.tar.xz" "$a"  # download, save tar.xz (tmpf)
+mkdir "$p" # add directory if not yet existing (including subtree)
+chown "$user":"$user" "$p" -R # permissions fix
+
+cd "$p" # avoid the does not get unpacked bug by joining dir
+
+curl -L -s -o "$tmpf" "$a"  # download, save tar.xz (tmpf)
 tar -xJf "$tmpf" # unpack tar.xz (tmpf)
+
+chown "$user":"$user" "$p" -R # permissions fix
 
 if [ ! -f "$tmpf" ]; then
   echo "[ERROR]: UPDATE FAILED temporary file: '$tmpf' not found! Looks like it was not downloaded from repo.";

--- a/update_spotube_on_linux.sh
+++ b/update_spotube_on_linux.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Script to update Spotube on Linux (direct binaries via tar.xz)
+# For letting it run in a crontab or manually
+
+# arch possibilities: either aarch64 or x86_6
+# path and tmpf (temp file for .tar.xz) whatever you choose
+
+# less sophisticated, old oneliner: arch="aarch64";p="/usr/share/spotube-bin"; a=$(curl -s https://api.github.com/repos/krtirtho/spotube/releases/latest | sed 's/[()",{}]/ /g; s/ /\n/g' | grep "https.*releases/download.*tar.xz" | grep "$arch"); wget "$a" -O "$p/test.tar.xz" && tar -xJf "$p/test.tar.xz"  && rm "$p/test.tar.xz" && echo "$(date -I'seconds')|$a" >> "$p/lastupdate.txt"
+
+
+p="/usr/share/spotube-bin" # Path where the tar.xz should be downloaded and unpacked
+tmpf="$p/test.tar.xz"
+repo="krtirtho/spotube" # define repo path
+url="https://api.github.com/repos/$repo/releases/latest"
+arch="x86_64" # arch?
+
+# check if running as root
+if [ $(id -u) -ne 0 ]; then
+  echo "[ERROR]: This updater must be run as root";
+  exit
+fi
+
+if [ "$arch" != "aarch64" ] && [ "$arch" != "x86_64" ]; then
+  echo "[ERROR]: UPDATE FAILED. Arch must be either x86_64 or aarch64. Currently it is: '$arch' "
+  exit
+fi
+
+a=$(curl -s "$url" | sed 's/[()",{}]/ /g; s/ /\n/g' | grep "https.*releases/download.*tar.xz" | grep "$arch") # select the correct binary from Github release path via JSON API
+if [ -z "$a" ]; then
+  echo "[ERROR]: UPDATE FAILED: Url '$url' is invalid, exiting.";
+  exit;
+fi
+
+# rm "$p/*" -r # optionally remove everything in the folder before (avoiding left overs and other issues)
+
+# creating $p dir, downloading & saving, unpacking tmpf/tar.xz
+mkdir -p "$p" # add directory if not yet existing (including subtree)
+curl -L -s -o "$p/test.tar.xz" "$a"  # download, save tar.xz (tmpf)
+tar -xJf "$tmpf" # unpack tar.xz (tmpf)
+
+if [ ! -f "$tmpf" ]; then
+  echo "[ERROR]: UPDATE FAILED temporary file: '$tmpf' not found! Looks like it was not downloaded from repo.";
+  exit;
+fi
+
+# when updated
+rm "$tmpf"
+echo "$(date -I'seconds')|$a" >> "$p/lastupdate.txt" # add datetime and tar.xz link entry to lastupdate.txt
+echo "[+] UPDATE LOOKS SUCCESSFUL. CHECK BY RUNNING $p/spotube";

--- a/update_spotube_on_linux.sh
+++ b/update_spotube_on_linux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Written 10. Okt. 2024 4pm Berlin Time (CEST)
+# Written on 10 Oct. 2024 4pm Berlin Time (CEST)
 
 # Script to update Spotube on Linux (direct binaries via tar.xz)
 # For letting it run in a crontab or manually


### PR DESCRIPTION
Hi, due to the last updates in a row (the 403 API issue fix). The current approach is not time efficient. I wanted something more automated.  Therefore I am contributing and sharing it among yall. 

- adds the bash script to update spotube either on aarch64 or on x86_64
- adds a logfile, using iso datetimes and the download url (for knowing when the last update was and what version) 

Script can be moved to `/usr/bin/updatespotube` with `chmod 0700 /usr/bin/updatespotube`&& chown root:root /usr/bin/updatespotube`, as a **root only executable**. Possibly it can be run with a cronjob within crontab. The untared files can still be executed by non-root, to my knowledge - not sure if what happens if the directory is fully recreated. 

- I need to add two things before merging. Found a tiny bug 