### PR TITLE
bug #2354: Fix icon overflow in Local Folder Cache page

### DIFF
--- a/lib/pages/library/user_local_tracks/local_folder.dart
+++ b/lib/pages/library/user_local_tracks/local_folder.dart
@@ -136,8 +136,10 @@ class LocalLibraryPage extends HookConsumerWidget {
                     icon: Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        const Icon(SpotubeIcons.delete),
-                        Text(context.l10n.clear_cache)
+                        const Expanded(child: Icon(SpotubeIcons.delete)),
+                        Text(
+                          context.l10n.clear_cache,
+                        )
                       ],
                     ).xSmall().iconSmall(),
                     onPressed: () async {
@@ -178,7 +180,7 @@ class LocalLibraryPage extends HookConsumerWidget {
                     icon: Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        const Icon(SpotubeIcons.export),
+                        const Expanded(child: Icon(SpotubeIcons.export)),
                         Text(
                           context.l10n.export,
                         )


### PR DESCRIPTION
This PR fixes the icon overflow issue in `local_folder.dart` on some screen sizes.

### Changes:

- Wrapped `Icon` inside `Expanded` to prevent layout breaking 


UI tested on Linux Desktop  

### Before:

![iconsoverflow](https://github.com/user-attachments/assets/487bba4b-d906-4c76-8229-7e995ef79146)

### After:

![image](https://github.com/user-attachments/assets/54f8e17a-9318-43a1-b9da-654b6ccd8497)

Fixes #2354