### PR TITLE
Fix dependencies on Debian Testing/Unstable (rolling release) systems

### DIFF
--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -15,7 +15,7 @@ dependencies:
   - gir1.2-appindicator3-0.1 | gir1.2-ayatanaappindicator3-0.1
   - libsecret-1-0
   - libnotify-bin
-  - libjsoncpp25
+  - libjsoncpp25 | libjsoncpp26
   - libmpv1 | libmpv2
   - xdg-user-dirs
   - avahi-daemon


### PR DESCRIPTION
The new version of libjsoncpp should have no breaking changes, as far as the [changelog](https://github.com/open-source-parsers/jsoncpp/releases/tag/1.9.6) is concerned.