### PR TITLE
fix: revise filter for ISRC search and support Unicode

### DIFF
--- a/lib/services/sourced_track/sources/youtube.dart
+++ b/lib/services/sourced_track/sources/youtube.dart
@@ -251,19 +251,18 @@ class YoutubeSourcedTrack extends SourcedTrack {
             .map((YoutubeVideoInfo videoInfo) {
               final ytWords = videoInfo.title
                   .toLowerCase()
-                  .replaceAll(RegExp(r'[^a-zA-Z0-9\s]+'), '')
-                  .split(RegExp(r'\s+'))
+                  .replaceAll(RegExp(r'[^\p{L}\p{N}\p{Z}]+', unicode: true), '')
+                  .split(RegExp(r'\p{Z}+', unicode: true))
                   .where((item) => item.isNotEmpty);
               final spWords = track.name!
                   .toLowerCase()
-                  .replaceAll(RegExp(r'\((.*)\)'), '')
-                  .replaceAll(RegExp(r'[^a-zA-Z0-9\s]+'), '')
-                  .split(RegExp(r'\s+'))
+                  .replaceAll(RegExp(r'[^\p{L}\p{N}\p{Z}]+', unicode: true), '')
+                  .split(RegExp(r'\p{Z}+', unicode: true))
                   .where((item) => item.isNotEmpty);
-              // Word match to filter out unrelated results
-              final matchCount =
-                  ytWords.where((word) => spWords.contains(word)).length;
-              if (matchCount > spWords.length ~/ 2) {
+              // Single word and duration match with 3 second tolerance
+              if (ytWords.any((word) => spWords.contains(word)) &&
+                  (videoInfo.duration - track.duration!)
+                      .abs().inMilliseconds <= 3000) {
                 return videoInfo;
               }
               return null;


### PR DESCRIPTION
CC @KRTirtho 

It seems that the current filter for ISRC search is too strict. For example, when Spotify has the track title `Track - Single Version`, and YouTube's ISRC title is named `Track`, the track gets filtered out.

Instead of strictly filtering on the track title (relax to match just one word), inspired by https://github.com/KRTirtho/spotube/issues/883#issuecomment-2760585789, track duration is added as a filtering method.

This way, random search queries are not added to the track sources, and at the same time, queries that are supposed to be added are not filtered out.

Moreover, I've fixed the issue where the Unicode titles of tracks get filtered out.