### PR TITLE
fix: prevent metadata corruption for weba and flac files

### DIFF
--- a/lib/provider/download_manager_provider.dart
+++ b/lib/provider/download_manager_provider.dart
@@ -239,7 +239,11 @@ class DownloadManagerNotifier extends Notifier<List<DownloadTask>> {
         return;
       }
 
-      if (container.getFileExtension() == "weba") return;
+      // Skip metadata writing for weba and flac to prevent file corruption
+      // FLAC files have strict header requirements and writing metadata after
+      // download can corrupt the sync code and make files unplayable
+      final extension = container.getFileExtension();
+      if (extension == "weba" || extension == "flac") return;
 
       final imageBytes = await ServiceUtils.downloadImage(
         (task.track.album.images).asUrlString(

--- a/lib/provider/server/routes/playback.dart
+++ b/lib/provider/server/routes/playback.dart
@@ -247,7 +247,11 @@ class ServerPlaybackRoutes {
 
         await trackPartialCacheFile.rename(trackCacheFile.path);
 
-        if (track.qualityPreset!.getFileExtension() == "weba") return;
+        // Skip metadata writing for weba and flac to prevent file corruption
+        // FLAC files have strict header requirements and writing metadata after
+        // download can corrupt the sync code and make files unplayable
+        final extension = track.qualityPreset!.getFileExtension();
+        if (extension == "weba" || extension == "flac") return;
 
         final imageBytes = await ServiceUtils.downloadImage(
           track.query.album.images.asUrlString(


### PR DESCRIPTION
- Skip metadata writing for flac files to prevent file corruption
- FLAC files have strict header requirements where writing metadata after download can corrupt the sync code and make files unplayable
- Update download_manager_provider.dart to check for both weba and flac extensions
- Update server/routes/playback.dart to check for both weba and flac extensions
- Add explanatory comments documenting why metadata writing is skipped for these formats
- Refactor extension checking to use variable assignment for clarity