### PR TITLE
Fix app crashing with NewPipe on Android versions older than 13

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -122,7 +122,7 @@ flutter {
 
 def glanceVersion = "1.1.1"
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.4'
 
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
     // other deps so just ignore

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -57,3 +57,8 @@
 -dontwarn jdk.dynalink.linker.support.CompositeTypeBasedGuardingDynamicLinker
 -dontwarn jdk.dynalink.linker.support.Guards
 -dontwarn jdk.dynalink.support.ChainedCallSite
+# Rules for jsoup
+# Ignore intended-to-be-optional re2j classes - only needed if using re2j for jsoup regex
+# jsoup safely falls back to JDK regex if re2j not on classpath, but has concrete re2j refs
+# See https://github.com/jhy/jsoup/issues/2459 - may be resolved in future, then this may be removed
+-dontwarn com.google.re2j.**


### PR DESCRIPTION


From NewPipeExtractor's README:

> To use NewPipe Extractor in Android projects with a minSdk below 33, core library desugaring with the desugar_jdk_libs_nio artifact is required.

Also version 2.0.4 works with Android Gradle Plugin versions older than 8.8.0 while 2.1.x does not.

This PR needs KRTirtho/flutter_new_pipe_extractor#4 to be merged so both repos have consistent dependencies.

Fixes #2880.