### PR TITLE
fix: hide followers count when null instead of showing Infinity

### DIFF
--- a/lib/pages/artist/section/header.dart
+++ b/lib/pages/artist/section/header.dart
@@ -192,20 +192,19 @@ class ArtistPageHeader extends HookConsumerWidget {
                             ),
                           ),
                           const Gap(5),
-                          Flexible(
-                            child: AutoSizeText(
-                              context.l10n.followers(
-                                artist.followers == null
-                                    ? double.infinity
-                                    : PrimitiveUtils.toReadableNumber(
-                                        artist.followers!.toDouble(),
-                                      ),
-                              ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              minFontSize: 12,
-                            ).muted(),
-                          ),
+                          if (artist.followers != null)
+                            Flexible(
+                              child: AutoSizeText(
+                                context.l10n.followers(
+                                  PrimitiveUtils.toReadableNumber(
+                                    artist.followers!.toDouble(),
+                                  ),
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                minFontSize: 12,
+                              ).muted(),
+                            ),
                           if (constrains.mdAndUp) ...[
                             const Gap(20),
                             actions,


### PR DESCRIPTION
## Summary
- Hide the followers count line when `artist.followers` is null instead of displaying "Infinity Followers"
- The MusicBrainz metadata plugin doesn't provide follower counts, so this field is always null

## Test plan
- Open an artist page with MusicBrainz and Last.fm enabled only (Spotify not enabled)
- Verify that "Infinity Followers" is no longer displayed
- If a metadata plugin that provides follower counts is used, verify followers are still shown correctly