### PR TITLE
Appdata improvements: Display size, repository URL

### DIFF
--- a/linux/com.github.KRTirtho.Spotube.appdata.xml
+++ b/linux/com.github.KRTirtho.Spotube.appdata.xml
@@ -12,6 +12,9 @@
     <control>keyboard</control>
     <control>touch</control>
   </recommends>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
   <developer_name>Kingkor Roy Tirtho</developer_name>
   <url type="bugtracker">https://github.com/krtirtho/spotube/issues</url>
   <url type="homepage">https://spotube.krtirtho.dev</url>

--- a/linux/com.github.KRTirtho.Spotube.appdata.xml
+++ b/linux/com.github.KRTirtho.Spotube.appdata.xml
@@ -16,6 +16,7 @@
   <url type="bugtracker">https://github.com/krtirtho/spotube/issues</url>
   <url type="homepage">https://spotube.krtirtho.dev</url>
   <url type="donation">https://opencollective.com/spotube</url>
+  <url type="vcs-browser">https://github.com/KRTirtho/spotube</url>
   <description>
     <p>Open source music client that doesn't require Premium nor uses Electron! Available for
       both desktop &amp; mobile!</p>


### PR DESCRIPTION
Hi,
thank you for creating this nice app that works great on #LinuxMobile!

This completes the recommended values for apps that work on desktops and mobile
See https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#desktop-and-mobile-apps
for reference. It also adds the repository URL, as some grumpy people have been leaving poor reviews when apps don't advertise where their source code lives.

With this change, a future release of the app should become a part of the [Flathub's Mobile Collection](https://flathub.org/en/apps/collection/mobile/1).

Hope it helps!
Cheers,
Peter