### PR TITLE
fix: white screen when play song from artists screen

### DIFF
--- a/lib/models/metadata/image.dart
+++ b/lib/models/metadata/image.dart
@@ -33,7 +33,7 @@ extension SpotubeImageExtensions on List<SpotubeImageObject>? {
     int index = 1,
     required ImagePlaceholder placeholder,
   }) {
-    final sortedImage = this?.sorted((a, b) => a.width!.compareTo(b.width!));
+    final sortedImage = this?.sorted((a, b) => (a.width ?? 0).compareTo(b.width ?? 0));
 
     return sortedImage != null && sortedImage.isNotEmpty
         ? sortedImage[


### PR DESCRIPTION
Fix issue #2949

In artist screen there was an error due to null check operator used on a null value. (using NewPipe and Spotify plugin)

So now if a.width or b.width are null are 0. This avoids the white screen which would be an unhandled error in Flutter

I tested and it works for me, no more white screen when you play songs from artist screen