### PR TITLE
fix: don't abort startup when launched headless (no Activity)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,7 +82,16 @@ Future<void> main(List<String> rawArgs) async {
 
     // force High Refresh Rate on some Android devices (like One Plus)
     if (kIsAndroid) {
-      await FlutterDisplayMode.setHighRefreshRate();
+      try {
+        await FlutterDisplayMode.setHighRefreshRate();
+      } catch (e, stack) {
+        // When the app is cold-started headless (e.g. by Android Auto's
+        // MediaBrowserService) there is no attached Activity, so this throws
+        // PlatformException(noActivity). Refresh-rate tuning is non-essential
+        // and must not abort bootstrap — otherwise runApp() never runs and the
+        // audio handler is never registered, hanging media browsers forever.
+        AppLogger.reportError(e, stack);
+      }
     }
     if (kIsAndroid || kIsDesktop) {
       await NewPipeExtractor.init();


### PR DESCRIPTION
## Summary
When the app is launched **headless** (no Activity attached) — e.g. by Android
Auto's `MediaBrowserService` or a media-button intent — `main()` calls
`FlutterDisplayMode.setHighRefreshRate()`, which throws
`PlatformException(noActivity)`. It was `await`ed unguarded, so the exception
**aborted `main()` before `runApp()`**. As a result the audio handler was never
registered and Android Auto (and any media browser) hung indefinitely on a
loading spinner.

## Fix
Wrap the non-essential high-refresh-rate call in `try/catch` so headless startup
completes and the audio service registers normally. No behavioural change when
an Activity is present.

## How to reproduce (before this change)
Cold-start the app from Android Auto / the Desktop Head Unit (force-stop it
first). The media app opens to a spinner that never resolves. With this change,
the browse tree loads.

## Scope
One file, `lib/main.dart`. Low risk.
