### PR TITLE
chore(ci): upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/spotube-release-binary.yml
+++ b/.github/workflows/spotube-release-binary.yml
@@ -88,7 +88,7 @@ jobs:
       #     df -h
       - name: Setup Java
         if: ${{matrix.platform == 'android'}}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: "zulu"
           java-version: "17"


### PR DESCRIPTION
## Summary

Upgrade the active release workflow from actions/setup-java v4 to v6. This adopts the current Node.js 24 action runtime while preserving the existing Java configuration.

## Validation

- Ran `git diff --check`.
- Verified no pre-v6 actions/setup-java references remain in active workflows.