### PR TITLE
fix: race condition between notification service init and playlist stream

### DIFF
--- a/lib/provider/audio_player/audio_player_streams.dart
+++ b/lib/provider/audio_player/audio_player_streams.dart
@@ -19,11 +19,10 @@ import 'package:spotube/services/logger/logger.dart';
 
 class AudioPlayerStreamListeners {
   final Ref ref;
-  late final AudioServices notificationService;
+  late final Future<AudioServices> notificationServiceFuture;
   AudioPlayerStreamListeners(this.ref) {
-    AudioServices.create(ref, ref.read(audioPlayerProvider.notifier)).then(
-      (value) => notificationService = value,
-    );
+    notificationServiceFuture =
+        AudioServices.create(ref, ref.read(audioPlayerProvider.notifier));
 
     final subscriptions = [
       subscribeToPlaylist(),
@@ -48,10 +47,11 @@ class AudioPlayerStreamListeners {
       ref.read(playbackHistoryActionsProvider);
 
   StreamSubscription subscribeToPlaylist() {
-    return audioPlayer.playlistStream.listen((mpvPlaylist) {
+    return audioPlayer.playlistStream.listen((mpvPlaylist) async {
       try {
         if (audioPlayerState.activeTrack == null) return;
-        notificationService.addTrack(audioPlayerState.activeTrack!);
+        final notificationService = await notificationServiceFuture;
+        await notificationService.addTrack(audioPlayerState.activeTrack!);
         discord.updatePresence(audioPlayerState.activeTrack!);
       } catch (e, stack) {
         AppLogger.reportError(e, stack);


### PR DESCRIPTION
## Issue

`AudioPlayerStreamListeners` kicks off `AudioServices.create(...)` asynchronously via `.then()`, assigning the result to a `late final AudioServices notificationService` field once it resolves. At the same time, it subscribes to `audioPlayer.playlistStream`. If a playlist event fires before the `.then()` callback has run, `notificationService` is accessed before it's ever assigned, throwing `LateInitializationError`.

This is easy to hit on Android Auto: AA can launch the app headless and immediately resume/start playback (e.g. last played song), so `playlistStream` can fire before `AudioService.init()` (notification channel + media session setup) completes well before it would in a normal foreground launch.

## Fix

Store the `Future<AudioServices>` itself instead of the resolved value, and `await` it wherever it's consumed:

```dart
late final Future<AudioServices> notificationServiceFuture;
notificationServiceFuture = AudioServices.create(ref, ...);
...
final notificationService = await notificationServiceFuture;
await notificationService.addTrack(...);
```

This removes the unsafe window entirely, callers just await the future, whether it's already resolved or not, instead of racing against a manually-assigned `late final`.

## Testing

- Reproduced on Android Auto (S10+ and my S23 Ultra with the Desktop Head Unit / real car unit) by letting AA auto-resume the last played track on headless launch.
- Confirmed the crash no longer occurs and the "now playing" state / notification populate correctly.

Related to #3064 (Android Auto browsing/playback) and should be merged before or together.