### PR TITLE
fix: UI prevent transient bottom overflow from mini-player animation

### DIFF
--- a/lib/modules/player/player_overlay.dart
+++ b/lib/modules/player/player_overlay.dart
@@ -28,26 +28,45 @@ class PlayerOverlay extends HookConsumerWidget {
 
     final panelController = ref.watch(playerOverlayControllerProvider);
 
-    return SlidingUpPanel(
-      maxHeight: screenSize.height,
-      backdropEnabled: false,
-      minHeight: canShow ? 63 : 0,
-      onPanelSlide: (position) {
-        final invertedPosition = 1 - position;
-        ref.read(navigationPanelHeight.notifier).state = 50 * invertedPosition;
-      },
-      controller: panelController,
-      color: Colors.transparent,
-      parallaxEnabled: true,
-      renderPanelSheet: false,
-      header: SizedBox(
-        height: 63,
-        width: screenSize.width,
-        child: PlayerOverlayCollapsedSection(panelController: panelController),
-      ),
-      panelBuilder: (scrollController) => PlayerView(
-        panelController: panelController,
-        scrollController: scrollController,
+    // [SlidingUpPanel] animates its own height between [minHeight] and
+    // [maxHeight] (the full screen height) while it is being opened/closed.
+    // Since this widget sits as a plain child inside the [Scaffold]'s
+    // footers column, that transient height briefly exceeds the collapsed
+    // [minHeight] slot it was given, overflowing the footers column by a
+    // few pixels. [OverflowBox] lets the panel keep painting at its actual
+    // (larger) size while reporting only the fixed collapsed height to its
+    // parent, so the outer layout never overflows.
+    return SizedBox(
+      height: canShow ? 63 : 0,
+      width: screenSize.width,
+      child: OverflowBox(
+        maxHeight: screenSize.height,
+        alignment: Alignment.bottomCenter,
+        child: SlidingUpPanel(
+          maxHeight: screenSize.height,
+          backdropEnabled: false,
+          minHeight: canShow ? 63 : 0,
+          onPanelSlide: (position) {
+            final invertedPosition = 1 - position;
+            ref.read(navigationPanelHeight.notifier).state =
+                50 * invertedPosition;
+          },
+          controller: panelController,
+          color: Colors.transparent,
+          parallaxEnabled: true,
+          renderPanelSheet: false,
+          header: SizedBox(
+            height: 63,
+            width: screenSize.width,
+            child: PlayerOverlayCollapsedSection(
+              panelController: panelController,
+            ),
+          ),
+          panelBuilder: (scrollController) => PlayerView(
+            panelController: panelController,
+            scrollController: scrollController,
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Fixes a `RenderFlex overflowed by ~18-24 pixels on the bottom` warning that fires whenever the mini-player (`PlayerOverlay`) appears/animates, e.g. right when a track starts playing.

## Root cause

`SlidingUpPanel` animates its own height between `minHeight` (collapsed, 63px) and `maxHeight` (full screen) while opening/closing. It's placed as a plain child inside the `Scaffold`'s `footers` column, which only gives it room for its collapsed `minHeight`. During the animation, `SlidingUpPanel` briefly reports a height larger than that collapsed slot, and since the footers column doesn't expect that, the total layout height exceeds the screen height by a few pixels triggering the overflow warning.

Verified this is a pre-existing bug on plain `master` (reproduced on a clean checkout with none of other changes present), not something introduced by my fixes nor fixed by other PRs.

## Fix

Wrap `SlidingUpPanel` in a fixed-size `SizedBox` + `OverflowBox`:

```dart
return SizedBox(
  height: canShow ? 63 : 0,
  width: screenSize.width,
  child: OverflowBox(
    maxHeight: screenSize.height,
    alignment: Alignment.bottomCenter,
    child: SlidingUpPanel(...),
  ),
);
```

`OverflowBox` lets the panel keep painting at its actual (larger, animated) size, while only ever reporting the fixed collapsed height to its parent so the outer `Scaffold` layout never overflows, and the panel still expands to full screen correctly when opened.

## Testing

- Reproduced by starting playback and observing the overflow banner in debug builds.
- Confirmed fixed after the change: same reproduction steps, no overflow warning in logs.
- Confirmed the full-screen "now playing" panel still opens/closes/animates correctly (not just clipped).
- Tested Devices: S10+ (LineageOS, Android 16), S23 (One UI 8.5, Android 16)
